### PR TITLE
Add robot_state_publisher to robot metapackage

### DIFF
--- a/robot/package.xml
+++ b/robot/package.xml
@@ -22,6 +22,7 @@
   <run_depend>nodelet_core</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>robot_model</run_depend>
+  <run_depend>robot_state_publisher</run_depend>
   <run_depend>ros_base</run_depend>
   <run_depend>xacro</run_depend>
 


### PR DESCRIPTION
In groovy, robot_model included robot_state_publisher as a run_depend, but it has been broken out to a separate repository in hydro. Currently, no hydro metapackage includes robot_state_publisher, a key component to pretty much all robots.
