### PR TITLE
Robot should really include control_msgs

### DIFF
--- a/robot/package.xml
+++ b/robot/package.xml
@@ -13,6 +13,7 @@
   <run_depend>actionlib</run_depend>
   <run_depend>bond_core</run_depend>
   <run_depend>common_msgs</run_depend>
+  <run_depend>control_msgs</run_depend>
   <run_depend>diagnostics</run_depend>
   <run_depend>driver_common</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>


### PR DESCRIPTION
In I-turtle, control_msgs is slated to move to common_msgs, for now we should include it in the standard robot metapackage as many, many robots are using it.
