### PR TITLE
Remove superfluous dependencies (already in viz)

### DIFF
--- a/desktop/package.xml
+++ b/desktop/package.xml
@@ -17,8 +17,6 @@
   <run_depend>geometry_tutorials</run_depend>
   <run_depend>ros_tutorials</run_depend>
   <run_depend>roslint</run_depend>
-  <run_depend>rqt_common_plugins</run_depend>
-  <run_depend>rqt_robot_plugins</run_depend>
   <run_depend>urdf_tutorial</run_depend>
   <run_depend>visualization_tutorials</run_depend>
 


### PR DESCRIPTION
The ros-desktop metapackage now only contains tutorials and roslint (which should probably go somewhere like core or base). So in principal we could rename this to ros-tutorials and ros-desktop-full to ros-desktop, but that's probably to late in the game...
