### PR TITLE
Added gennodejs Javascript message gen to ros_core

### DIFF
--- a/ros_core/package.xml
+++ b/ros_core/package.xml
@@ -17,6 +17,7 @@
   <run_depend>geneus</run_depend>
   <run_depend>genlisp</run_depend>
   <run_depend>genmsg</run_depend>
+  <run_depend>gennodejs</run_depend>
   <run_depend>genpy</run_depend>
   <run_depend>message_generation</run_depend>
   <run_depend>message_runtime</run_depend>


### PR DESCRIPTION
This adds the `gennodejs` as a core ROS package:
https://github.com/RethinkRobotics-opensource/gennodejs

This will be used with `rosjs` Javascript ROS client library (which will likely be renamed `rosnodejs`):
https://github.com/RethinkRobotics-opensource/rosjs

This PR supersedes #10 
