### PR TITLE
moving urdf_tutorials to desktop_full due to use of simulator. 

### DIFF
--- a/desktop/package.xml
+++ b/desktop/package.xml
@@ -19,7 +19,6 @@
   <run_depend>roslint</run_depend>
   <run_depend>rqt_common_plugins</run_depend>
   <run_depend>rqt_robot_plugins</run_depend>
-  <run_depend>urdf_tutorial</run_depend>
   <run_depend>visualization_tutorials</run_depend>
 
   <export>

--- a/desktop_full/package.xml
+++ b/desktop_full/package.xml
@@ -13,6 +13,7 @@
   <run_depend>desktop</run_depend>
   <run_depend>perception</run_depend>
   <run_depend>simulators</run_depend>
+  <run_depend>urdf_tutorial</run_depend>
 
   <export>
     <metapackage/>


### PR DESCRIPTION
Fixes #13. 

This will also need an associated update to REP 142.