### PR TITLE
Update Indigo to conform to latest changes in REP-142

### DIFF
--- a/desktop/package.xml
+++ b/desktop/package.xml
@@ -13,12 +13,11 @@
   <run_depend>robot</run_depend>
   <run_depend>viz</run_depend>
 
+  <run_depend>angles</run_depend>
   <run_depend>common_tutorials</run_depend>
   <run_depend>geometry_tutorials</run_depend>
   <run_depend>ros_tutorials</run_depend>
   <run_depend>roslint</run_depend>
-  <run_depend>rqt_common_plugins</run_depend>
-  <run_depend>rqt_robot_plugins</run_depend>
   <run_depend>visualization_tutorials</run_depend>
 
   <export>

--- a/desktop_full/package.xml
+++ b/desktop_full/package.xml
@@ -13,6 +13,7 @@
   <run_depend>desktop</run_depend>
   <run_depend>perception</run_depend>
   <run_depend>simulators</run_depend>
+
   <run_depend>urdf_tutorial</run_depend>
 
   <export>


### PR DESCRIPTION
In particular:

1.  Add "angles" to desktop
2.  Remove "rqt_common_plugins" and "rqt_robot_plugins" from
    desktop (they are inherited through viz).
3.  Separate the packages in desktop_full.

The rest already conforms to REP-142.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>