### PR TITLE
separate rosconsole

### DIFF
--- a/ros_base/package.xml
+++ b/ros_base/package.xml
@@ -20,10 +20,8 @@
 
   <exec_depend>actionlib</exec_depend>
   <exec_depend>bond_core</exec_depend>
-  <exec_depend>class_loader</exec_depend>
   <exec_depend>dynamic_reconfigure</exec_depend>
   <exec_depend>nodelet_core</exec_depend>
-  <exec_depend>pluginlib</exec_depend>
 
   <export>
     <metapackage/>

--- a/ros_core/package.xml
+++ b/ros_core/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <exec_depend>catkin</exec_depend>
+  <exec_depend>class_loader</exec_depend>
   <exec_depend>cmake_modules</exec_depend>
   <exec_depend>common_msgs</exec_depend>
   <exec_depend>gencpp</exec_depend>
@@ -27,9 +28,11 @@
   <exec_depend>genpy</exec_depend>
   <exec_depend>message_generation</exec_depend>
   <exec_depend>message_runtime</exec_depend>
+  <exec_depend>pluginlib</exec_depend>
   <exec_depend>ros</exec_depend>
   <exec_depend>ros_comm</exec_depend>
   <exec_depend>rosbag_migration_rule</exec_depend>
+  <exec_depend>rosconsole</exec_depend>
   <exec_depend>rosconsole_bridge</exec_depend>
   <exec_depend>roscpp_core</exec_depend>
   <exec_depend>rosgraph_msgs</exec_depend>


### PR DESCRIPTION
See ros/rosdistro#17919.

Separating `rosconsole` and moving `pluginlib` and `class_loader` from "ros_base" to "ros_core".