### PR TITLE
Add actionlib_tools to desktop

### DIFF
--- a/desktop/package.xml
+++ b/desktop/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>robot</exec_depend>
   <exec_depend>viz</exec_depend>
 
+  <exec_depend>actionlib_tools</exec_depend>
   <exec_depend>angles</exec_depend>
   <exec_depend>common_tutorials</exec_depend>
   <exec_depend>geometry_tutorials</exec_depend>


### PR DESCRIPTION
Previously, `actionlib` contained two GUI tools, causing a dependency on `python-wxtools` which pulled in several GUI dependencies. This violates REP 142/150, which states that `ros_base` (which contains `actionlib`) "may not contain any GUI dependencies".

These GUI tools have been broken out into the new `actionlib_tools` package in Noetic, ~and will be broken out in Indigo-Melodic once ros/actionlib#157 is merged~.

@mikepurvis and others recommend adding the new `actionlib_tools` package as a dependency of the `desktop` metapackage.