### PR TITLE
Add joint_state_publisher_gui to the desktop metapackage.

### DIFF
--- a/desktop/package.xml
+++ b/desktop/package.xml
@@ -22,6 +22,7 @@
   <exec_depend>angles</exec_depend>
   <exec_depend>common_tutorials</exec_depend>
   <exec_depend>geometry_tutorials</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>ros_tutorials</exec_depend>
   <exec_depend>roslint</exec_depend>
   <exec_depend>urdf_tutorial</exec_depend>


### PR DESCRIPTION
joint_state_publisher and joint_state_publisher_gui were
split into separate packages to remove a GUI dependency
from the robot metapackage.  Add the GUI version back
to desktop so that users can still get the GUI functionality
when they install the desktop variant.

Signed-off-by: Chris Lalancette <clalancette@gmail.com>

This goes along with https://github.com/ros-infrastructure/rep/pull/230