### PR TITLE
Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(desktop)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/desktop_full/CMakeLists.txt
+++ b/desktop_full/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(desktop_full)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/perception/CMakeLists.txt
+++ b/perception/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(perception)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/robot/CMakeLists.txt
+++ b/robot/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(robot)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/ros_base/CMakeLists.txt
+++ b/ros_base/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ros_base)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/ros_core/CMakeLists.txt
+++ b/ros_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ros_core)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/simulators/CMakeLists.txt
+++ b/simulators/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(simulators)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/viz/CMakeLists.txt
+++ b/viz/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(viz)
 find_package(catkin REQUIRED)
 catkin_metapackage()


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

ros/catkin#1052

Signed-off-by: ahcorde <ahcorde@gmail.com>