### PR TITLE
Temporarily remove kdl_parser_py from robot

### DIFF
--- a/robot/package.xml
+++ b/robot/package.xml
@@ -25,7 +25,8 @@
   <exec_depend>geometry</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>kdl_parser</exec_depend>
-  <exec_depend>kdl_parser_py</exec_depend>
+  <!-- Ignore kdl_parser_py until it becomes usable in Ubuntu Focal -->
+  <!--<exec_depend>kdl_parser_py</exec_depend>-->
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>urdf</exec_depend>
   <exec_depend>urdf_parser_plugin</exec_depend>


### PR DESCRIPTION
This temporarily removes `kdl_parser_py` from the `robot` metapackage. `kdl_parser_py` was not released into Noetic because the library it depends on `PyKDL` is unusable in Focal. This PR would allow `metapackages` to be released without waiting for this to be fixed (once `urdf_sim_tutorial` and `gazebo_ros_pkgs` are released). This should be undone once an SRU for PyKDL is complete.

https://bugs.launchpad.net/ubuntu/+source/orocos-kdl/+bug/1871725

I think this is ok because the package does not seem to be frequently used. Looking at all the [`package.xml` caches](https://github.com/ros/rosdistro/blob/master/index-v4.yaml) in Indigo, Jade, Kinetic, Lunar, and Melodic, the only package in 5 ROS releases that has depended on `kdl_parser_py` is `ros-melodic-robot`. That does not say how many packages which are not released into ROS distros have depended on it, but I would expect it to be a small number, and those same packages would be blocked by `PyKDL` being broken in Focal.